### PR TITLE
ImportError for ansi file

### DIFF
--- a/draftlog/drafter.py
+++ b/draftlog/drafter.py
@@ -1,8 +1,8 @@
 from .logdraft import LogDraft
+from . import ansi
 import draftlog
 import time
 import sys
-import ansi
 import threading
 
 # Imports the correct module according to

--- a/draftlog/logdraft.py
+++ b/draftlog/logdraft.py
@@ -1,4 +1,4 @@
-import ansi
+from . import ansi
 import sys
 
 """


### PR DESCRIPTION
I was getting `ImportError: No module named 'ansi'` left and right, this fixed that. Sorry for being so messy with so many commits - I was trying to do it all on web for 2 lines of code :D