### PR TITLE
Fixed silent tput failure on Windows

### DIFF
--- a/draftlog/lcs.py
+++ b/draftlog/lcs.py
@@ -4,6 +4,7 @@ LCS: Line Count Stream
 from draftlog.logdraft import LogDraft
 from draftlog.drafter import Drafter
 import os
+import subprocess
 import sys
 
 """
@@ -20,8 +21,8 @@ class LineCountStream(object):
 
         # Reads the command "tput lines" if valid
         try:
-            self.rows = os.popen("tput lines").read()
-        except ValueError:
+            self.rows = subprocess.Popen("tput lines").read()
+        except (ValueError, FileNotFoundError):
             self.rows = 20
 
     """

--- a/draftlog/lcs.py
+++ b/draftlog/lcs.py
@@ -22,7 +22,7 @@ class LineCountStream(object):
         # Reads the command "tput lines" if valid
         try:
             self.rows = subprocess.Popen("tput lines").read()
-        except (ValueError, IOError):
+        except (ValueError, IOError, OSError):
             self.rows = 20
 
     """

--- a/draftlog/lcs.py
+++ b/draftlog/lcs.py
@@ -22,7 +22,7 @@ class LineCountStream(object):
         # Reads the command "tput lines" if valid
         try:
             self.rows = subprocess.Popen("tput lines").read()
-        except (ValueError, FileNotFoundError):
+        except (ValueError, IOError):
             self.rows = 20
 
     """


### PR DESCRIPTION
Using the subprocess popen raises an exception when the command/file is not found.
This _shouldn't_ break compatability with Unix versions but ¯\_(ツ)_/¯ you decide.